### PR TITLE
Fix broken Docker container names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ pull:
 	docker pull jrcs/letsencrypt-nginx-proxy-companion
 
 stop:
-	docker stop nginx-proxy lets-encrypt
-	docker rm nginx-proxy lets-encrypt
+	docker stop nginx-proxy nginx-proxy-letsencrypt
+	docker rm nginx-proxy nginx-proxy-letsencrypt
 
 start:
 	docker run --detach \


### PR DESCRIPTION
'make stop' tries to stop docker container lets-encrypt which does not exist. The container name is specified as nginx-proxy-letsencrypt in the 'make start' section